### PR TITLE
Made hotfixes to doxygen comments (added whitespaces)

### DIFF
--- a/src/Pathfinding_mock/graph.hpp
+++ b/src/Pathfinding_mock/graph.hpp
@@ -12,17 +12,17 @@
 
 namespace Pathfinding {
 class Graph {
-    //< This is a mock class of the Graph class used by path finding.
-    //< It contains a (dummy) implementations of the methods that are
-    //< relevant for this module (mapping) in order to create a new
-    //< instance of Pathfinding::Graph. The content of this file is
-    //< based on the state of the development branch of PATHFINDING
-    //< at 11:56 PM 31/5/2018. When the module gets updated, this
-    //< file needs to be cahnged manually.
-    //< Unfortunately, the pathfinding module is running on a
-    //< different platform currently, so it is not possible to
-    //< simply include the file from the pathfinding repo, however
-    //< that would be desirable.
+    ///< This is a mock class of the Graph class used by path finding.
+    ///< It contains a (dummy) implementations of the methods that are
+    ///< relevant for this module (mapping) in order to create a new
+    ///< instance of Pathfinding::Graph. The content of this file is
+    ///< based on the state of the development branch of PATHFINDING
+    ///< at 11:56 PM 31/5/2018. When the module gets updated, this
+    ///< file needs to be cahnged manually.
+    ///< Unfortunately, the pathfinding module is running on a
+    ///< different platform currently, so it is not possible to
+    ///< simply include the file from the pathfinding repo, however
+    ///< that would be desirable.
   public:
     /**
      * @brief Construct a new Graph object

--- a/src/Pathfinding_mock/node.hpp
+++ b/src/Pathfinding_mock/node.hpp
@@ -11,17 +11,17 @@
 #include <stdint.h>
 
 namespace Pathfinding {
-//< This is a mock class of the Node class used by path finding.
-//< It contains a (dummy) implementations of the methods that are
-//< relevant for this module (mapping) in order to create a new
-//< instance of Pathfinding::Graph. The content of this file is
-//< based on the state of the development branch of PATHFINDING
-//< at 11:56 PM 31/5/2018. When the module gets updated, this
-//< file needs to be cahnged manually.
-//< Unfortunately, the pathfinding module is running on a
-//< different platform currently, so it is not possible to
-//< simply include the file from the pathfinding repo, however
-//< that would be desirable.
+///< This is a mock class of the Node class used by path finding.
+///< It contains a (dummy) implementations of the methods that are
+///< relevant for this module (mapping) in order to create a new
+///< instance of Pathfinding::Graph. The content of this file is
+///< based on the state of the development branch of PATHFINDING
+///< at 11:56 PM 31/5/2018. When the module gets updated, this
+///< file needs to be cahnged manually.
+///< Unfortunately, the pathfinding module is running on a
+///< different platform currently, so it is not possible to
+///< simply include the file from the pathfinding repo, however
+///< that would be desirable.
 class Node {
   public:
     /**

--- a/src/math/math.hpp
+++ b/src/math/math.hpp
@@ -21,6 +21,7 @@ namespace math {
  * If the sum of the mask (0x10) is true, a temporary integer result will be incremented(*=) by the base value. \n
  * By shifting all the bits of the exponent to the right by one, you binary deincrement the value. \n
  * The base gets multiplyplied by it self and the loop proceeds until the binary value of the exponent becomes 0x00
+ *
  * @param base
  * @param exp
  * @return integer
@@ -31,6 +32,7 @@ int pow(int base, int exp);
  * @brief Exponentation of floating pointer
  * @details This function returns a exponentation of a base by a user defined exponent. \n
  * There are no special techniques being used in this function. just a simple for loop with a result being multiplied by its base.
+ *
  * @param base
  * @param exp
  * @return float
@@ -41,6 +43,7 @@ float pow(float base, int exp);
  * @brief Calculation of absolute value of a integer
  * @details This function was made by Jens Gustedt
  * @ref https://stackoverflow.com/questions/9772348/get-absolute-value-without-using-abs-function-nor-if-statement
+ *
  * @param v
  * @return integer
  */
@@ -49,6 +52,7 @@ int abs(int v);
  * @brief Calculation of absolute value of a floatig pointer
  * @details This function was made by Jens Gustedt
  * @ref https://stackoverflow.com/questions/9772348/get-absolute-value-without-using-abs-function-nor-if-statement
+ *
  * @param v
  * @return floating pointer
  */
@@ -56,6 +60,7 @@ float abs(float v);
 
 /**
  * @brief Two Babylonian Steps (simplfied) square root
+ *
  * @param x
  * @return float
  */
@@ -63,6 +68,7 @@ float sqrt(const float x);
 
 /**
  * @brief Function used to round a floating pointer up.
+ *
  * @param num
  * @return
  */
@@ -76,6 +82,7 @@ int ceil(float num);
  * The complete explanation of the workings of this point generating method is rather difficult to explain.
  * Please see the link for more info.
  * @ref https://en.wikipedia.org/wiki/B%C3%A9zier_curve
+ *
  * @param n1
  * @param n2
  * @param perc
@@ -84,6 +91,7 @@ int ceil(float num);
 int getPt(int n1, int n2, float perc);
 /**
  * @brief Simple Factoral calculation of a floating pointer
+ *
  * @param x
  * @return float
  */
@@ -92,6 +100,7 @@ float fact(int x);
 /**
  * @brief Modified Taylor series cos alghorithm
  * @details This is a modified algortihm made by a Professor in MIT. His name was unkown however.
+ *
  * @param x
  * @return float
  */
@@ -100,6 +109,7 @@ float cos(float x);
 /**
  * @brief Modified Taylor series sin alghorithm
  * @details This is a modified algortihm made by a Professor in MIT. His name was unkown however.
+ *
  * @param x
  * @return float
  */
@@ -109,6 +119,7 @@ float sin(float x);
  * @brief This function will convert a integer to a char array.
  * @details a integer and a char arrray have to be givin to the function. \n
  * The function converts the integer to a char array and will fill the given char array with the content
+ *
  * @param n
  * @param ch1
  */
@@ -116,6 +127,7 @@ void int_to_string(int n, char ch1[]);
 
 /**
  * @brief This function will return the atan of a float
+ *
  * @param inX
  * @return float
  */
@@ -123,6 +135,7 @@ float atan(float inX);
 
 /**
  * @brief This function will return the acos of a float
+ *
  * @param inX
  * @return float
  */


### PR DESCRIPTION
Added whitespaces between `details` and `param` in doxygen comments